### PR TITLE
Port to FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ doc = ["file-lock", "unprivileged", "tokio-runtime"]
 futures-util = { version = "0.3", features = ["sink"] }
 futures-channel = { version = "0.3", features = ["sink"] }
 async-trait = "0.1"
+cstr = "0.2"
 libc = "0.2"
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,9 @@ optional = true
 
 [package.metadata.docs.rs]
 features = [ "doc" ]
+targets = [
+  "i686-unknown-freebsd",
+  "i686-unknown-linux-gnu",
+  "x86_64-unknown-freebsd",
+  "x86_64-unknown-linux-gnu",
+]

--- a/examples/src/memfs/main.rs
+++ b/examples/src/memfs/main.rs
@@ -12,6 +12,7 @@ use bytes::{Buf, Bytes, BytesMut};
 use futures_util::stream;
 use futures_util::stream::{Empty, Iter};
 use futures_util::StreamExt;
+use libc::mode_t;
 use tokio::sync::RwLock;
 use tracing::Level;
 
@@ -138,7 +139,7 @@ struct Dir {
     parent: u64,
     name: OsString,
     children: BTreeMap<OsString, Entry>,
-    mode: u32,
+    mode: mode_t,
 }
 
 #[derive(Debug)]
@@ -147,7 +148,7 @@ struct File {
     parent: u64,
     name: OsString,
     content: Vec<u8>,
-    mode: u32,
+    mode: mode_t,
 }
 
 #[derive(Debug)]
@@ -292,7 +293,7 @@ impl Filesystem for Fs {
                 parent,
                 name: name.to_owned(),
                 children: BTreeMap::new(),
-                mode,
+                mode: mode as mode_t,
             })));
 
             let attr = entry.attr().await;
@@ -585,7 +586,7 @@ impl Filesystem for Fs {
                 parent,
                 name: name.to_os_string(),
                 content: vec![],
-                mode,
+                mode: mode as mode_t,
             })));
 
             let attr = entry.attr().await;
@@ -816,6 +817,7 @@ async fn main() {
 
     let mount_options = MountOptions::default()
         // .allow_other(true)
+        .fs_name("memfs")
         .force_readdir_plus(true)
         .uid(uid)
         .gid(gid);

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -27,11 +27,11 @@ pub fn get_first_null_position(data: impl AsRef<[u8]>) -> Option<usize> {
 #[allow(trivial_numeric_casts)]
 /// returns the mode for a given file kind and permission
 pub fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
-    mode_t::from(kind) | perm as u32
+    (mode_t::from(kind) | perm as mode_t).into()
 }
 
 /// returns the permission for a given file kind and mode
-pub fn perm_from_mode_and_kind(kind: FileType, mode: u32) -> u16 {
+pub fn perm_from_mode_and_kind(kind: FileType, mode: mode_t) -> u16 {
     (mode ^ mode_t::from(kind)) as u16
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl From<FileType> for mode_t {
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct SetAttr {
     /// set file or directory mode.
-    pub mode: Option<u32>,
+    pub mode: Option<mode_t>,
     /// set file or directory uid.
     pub uid: Option<u32>,
     /// set file or directory gid.
@@ -111,7 +111,7 @@ impl From<&fuse_setattr_in> for SetAttr {
         let mut set_attr = Self::default();
 
         if setattr_in.valid & FATTR_MODE > 0 {
-            set_attr.mode = Some(setattr_in.mode);
+            set_attr.mode = Some(setattr_in.mode as mode_t);
         }
 
         if setattr_in.valid & FATTR_UID > 0 {


### PR DESCRIPTION
* Use a newer Nix, with nmount support.
* Use nmount on FreeBSD instead of mount.
* Deal with 16-bit mode_t
* Disable fallocate in some examples, not yet supported by FreeBSD's fusefs
* Do nothing special to mount without privileges on FreeBSD.  Unlike Linux,
  it will just work if the system is configured to allow it.
* Open /dev/fuse with O_NONBLOCK, rather than setting it later.
* Set fs_name in one of the examples, for demonstration purposes.

Note: FreeBSD 14.0-CURRENT is required, with a build from
7b8622fa220b9c08041102f638f848c48e022644 or later.