### PR TITLE
Update Nix to the latest, which changes error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "0.1"
 libc = "0.2"
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
-nix = "0.20"
+nix = "0.22.0"
 which = { version = "4.0", optional = true }
 tokio-stream = { version = "0.1", features = ["fs"], optional = true }
 async-io = { version = "1.3", optional = true }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -40,17 +40,13 @@ impl From<Errno> for IoError {
 
 impl From<NixError> for Errno {
     fn from(err: NixError) -> Self {
-        match err {
-            NixError::Sys(errno) => Errno(errno as libc::c_int),
-            NixError::InvalidPath | NixError::InvalidUtf8 => Errno(libc::EINVAL),
-            NixError::UnsupportedOperation => Errno(libc::ENOTSUP),
-        }
+        Errno(err as libc::c_int)
     }
 }
 
 impl From<Errno> for NixError {
     fn from(errno: Errno) -> Self {
-        NixError::from_errno(nix::errno::from_i32(errno.0))
+        nix::errno::from_i32(errno.0)
     }
 }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,5 +1,3 @@
-use std::io;
-use std::io::ErrorKind;
 use std::mem;
 
 use bincode::{DefaultOptions, Options};
@@ -42,17 +40,6 @@ pub fn get_padding_size(dir_entry_size: usize) -> usize {
     let entry_size = (dir_entry_size + mem::size_of::<u64>() - 1) & !(mem::size_of::<u64>() - 1); // 64bit align
 
     entry_size - dir_entry_size
-}
-
-#[inline]
-pub fn io_error_from_nix_error(err: nix::Error) -> io::Error {
-    match err {
-        nix::Error::Sys(errno) => io::Error::from_raw_os_error(errno as i32),
-        nix::Error::UnsupportedOperation => io::Error::new(ErrorKind::Other, err),
-        nix::Error::InvalidPath | nix::Error::InvalidUtf8 => {
-            io::Error::from(ErrorKind::InvalidInput)
-        }
-    }
 }
 
 pub fn get_bincode_config() -> impl Options {

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -154,7 +154,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
         ) {
             error!("mount {:?} failed", mount_path);
 
-            return Err(io_error_from_nix_error(err));
+            return Err(err.into());
         }
 
         self.fuse_connection.replace(Arc::new(fuse_connection));


### PR DESCRIPTION
Nix 0.22.0 implements From in both directions between Nix::Error and
io::Error.