### PR TITLE
Allow non-sequential directory offsets

### DIFF
--- a/examples/src/helloworld/main.rs
+++ b/examples/src/helloworld/main.rs
@@ -183,16 +183,19 @@ impl Filesystem for HelloWorld {
                 inode: PARENT_INODE,
                 kind: FileType::Directory,
                 name: OsString::from("."),
+                offset: 1
             }),
             Ok(DirectoryEntry {
                 inode: PARENT_INODE,
                 kind: FileType::Directory,
                 name: OsString::from(".."),
+                offset: 2
             }),
             Ok(DirectoryEntry {
                 inode: FILE_INODE,
                 kind: FileType::RegularFile,
                 name: OsString::from(FILE_NAME),
+                offset: 3
             }),
         ];
 
@@ -231,6 +234,7 @@ impl Filesystem for HelloWorld {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from("."),
+                offset: 1,
                 attr: FileAttr {
                     ino: PARENT_INODE,
                     generation: 0,
@@ -255,6 +259,7 @@ impl Filesystem for HelloWorld {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from(".."),
+                offset: 2,
                 attr: FileAttr {
                     ino: PARENT_INODE,
                     generation: 0,
@@ -279,6 +284,7 @@ impl Filesystem for HelloWorld {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from(FILE_NAME),
+                offset: 3,
                 attr: FileAttr {
                     ino: FILE_INODE,
                     generation: 0,

--- a/examples/src/path_memfs/main.rs
+++ b/examples/src/path_memfs/main.rs
@@ -746,23 +746,26 @@ impl PathFilesystem for Fs {
 
         if let Entry::Dir(dir) = entry {
             let pre_children = vec![
-                (FileType::Directory, OsString::from("."), entry.attr()),
-                (FileType::Directory, OsString::from(".."), parent.attr()),
+                (FileType::Directory, OsString::from("."), entry.attr(), 1),
+                (FileType::Directory, OsString::from(".."), parent.attr(), 2),
             ];
 
             let pre_children = stream::iter(pre_children);
 
             let children = pre_children
-                .chain(stream::iter(dir.children.iter()).map(|(name, entry)| {
-                    let kind = entry.kind();
-                    let name = name.to_owned();
-                    let attr = entry.attr();
+                .chain(stream::iter(dir.children.iter())
+                   .enumerate()
+                   .map(|(i, (name, entry))| {
+                        let kind = entry.kind();
+                        let name = name.to_owned();
+                        let attr = entry.attr();
 
-                    (kind, name, attr)
-                }))
-                .map(|(kind, name, attr)| DirectoryEntryPlus {
+                        (kind, name, attr, i as i64 + 3)
+                    })
+                ).map(|(kind, name, attr, offset)| DirectoryEntryPlus {
                     kind,
                     name,
+                    offset,
                     attr,
                     entry_ttl: TTL,
                     attr_ttl: TTL,

--- a/examples/src/poll/main.rs
+++ b/examples/src/poll/main.rs
@@ -182,16 +182,19 @@ impl Filesystem for Poll {
                 inode: PARENT_INODE,
                 kind: FileType::Directory,
                 name: OsString::from("."),
+                offset: 1,
             }),
             Ok(DirectoryEntry {
                 inode: PARENT_INODE,
                 kind: FileType::Directory,
                 name: OsString::from(".."),
+                offset: 2,
             }),
             Ok(DirectoryEntry {
                 inode: FILE_INODE,
                 kind: FileType::RegularFile,
                 name: OsString::from(FILE_NAME),
+                offset: 3,
             }),
         ];
 
@@ -230,6 +233,7 @@ impl Filesystem for Poll {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from("."),
+                offset: 1,
                 attr: FileAttr {
                     ino: PARENT_INODE,
                     generation: 0,
@@ -254,6 +258,7 @@ impl Filesystem for Poll {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from(".."),
+                offset: 2,
                 attr: FileAttr {
                     ino: PARENT_INODE,
                     generation: 0,
@@ -278,6 +283,7 @@ impl Filesystem for Poll {
                 generation: 0,
                 kind: FileType::Directory,
                 name: OsString::from(FILE_NAME),
+                offset: 3,
                 attr: FileAttr {
                     ino: FILE_INODE,
                     generation: 0,

--- a/src/path/inode_path_bridge.rs
+++ b/src/path/inode_path_bridge.rs
@@ -773,6 +773,7 @@ where
                 inode,
                 kind: entry.kind,
                 name: entry.name,
+                offset: entry.offset
             }));
         }
 
@@ -1083,6 +1084,7 @@ where
                 generation: 0,
                 kind: entry.kind,
                 name: entry.name,
+                offset: entry.offset,
                 attr: (inode, entry.attr).into(),
                 entry_ttl: entry.entry_ttl,
                 attr_ttl: entry.attr_ttl,

--- a/src/path/reply.rs
+++ b/src/path/reply.rs
@@ -107,6 +107,8 @@ pub struct DirectoryEntry {
     pub kind: FileType,
     /// entry name.
     pub name: OsString,
+    /// Directory offset of the _next_ entry
+    pub offset: i64
 }
 
 /// readdir reply.
@@ -129,6 +131,8 @@ pub struct DirectoryEntryPlus {
     pub kind: FileType,
     /// the entry name.
     pub name: OsString,
+    /// Directory offset of the _next_ entry
+    pub offset: i64,
     /// the entry attribute.
     pub attr: FileAttr,
     /// the entry TTL.

--- a/src/raw/reply.rs
+++ b/src/raw/reply.rs
@@ -253,6 +253,8 @@ pub struct DirectoryEntry {
     pub kind: FileType,
     /// entry name.
     pub name: OsString,
+    /// Directory offset of the _next_ entry
+    pub offset: i64
 }
 
 /// readdir reply.
@@ -379,6 +381,8 @@ pub struct DirectoryEntryPlus {
     pub kind: FileType,
     /// the entry name.
     pub name: OsString,
+    /// Directory offset of the _next_ entry
+    pub offset: i64,
     /// the entry attribute.
     pub attr: FileAttr,
     /// the entry TTL.

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -2637,7 +2637,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
             let entries = reply_readdir.entries;
             pin_mut!(entries);
 
-            let mut entry_index = read_in.offset;
             while let Some(entry) = entries.next().await {
                 let entry = match entry {
                     Err(err) => {
@@ -2648,8 +2647,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
                     Ok(entry) => entry,
                 };
-
-                entry_index += 1;
 
                 let name = &entry.name;
 
@@ -2663,7 +2660,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
                 let dir_entry = fuse_dirent {
                     ino: entry.inode,
-                    off: entry_index,
+                    off: entry.offset as u64,
                     namelen: name.len() as u32,
                     // learn from fuse-rs and golang bazil.org fuse DirentType
                     r#type: mode_from_kind_and_perm(entry.kind, 0) >> 12,
@@ -3545,7 +3542,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
             let entries = directory_plus.entries;
             pin_mut!(entries);
 
-            let mut entry_index = readdirplus_in.offset;
             while let Some(entry) = entries.next().await {
                 let entry = match entry {
                     Err(err) => {
@@ -3556,8 +3552,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
                     Ok(entry) => entry,
                 };
-
-                entry_index += 1;
 
                 let name = &entry.name;
 
@@ -3583,7 +3577,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
                     },
                     dirent: fuse_dirent {
                         ino: entry.inode,
-                        off: entry_index,
+                        off: entry.offset as u64,
                         namelen: name.len() as u32,
                         // learn from fuse-rs and golang bazil.org fuse DirentType
                         r#type: mode_from_kind_and_perm(entry.kind, 0) >> 12,


### PR DESCRIPTION
The FUSE protocol allows each directory entry to include a off field in
struct fuse_dirent. It's purpose is to uniquely identify a directory
entry so that a future FUSE_READDIR operation may continue where a
previous one left off. The FUSE file system is allowed to choose the
format of those off values. In particular, sequentially increasing
indexes are usually not adequate, because if a directory entry is
deleted in between two FUSE_READDIR operations, using sequential off
values could lead to skipping over a directory entry.

Instead of attempting to manage those offsets with fuse3, forcing them
to be sequential, pass responsibility to the file system.

Fixes #12