### PR TITLE
Don't require the file system to implement open

### DIFF
--- a/src/path/path_filesystem.rs
+++ b/src/path/path_filesystem.rs
@@ -169,7 +169,7 @@ pub trait PathFilesystem {
     /// [fuse_common.h](https://libfuse.github.io/doxygen/include_2fuse__common_8h_source.html) for
     /// more details.
     async fn open(&self, req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
-        Err(libc::ENOSYS.into())
+        Ok(ReplyOpen { fh: 0, flags: 0 })
     }
 
     /// read data. Read should send exactly the number of bytes requested except on EOF or error,

--- a/src/raw/filesystem.rs
+++ b/src/raw/filesystem.rs
@@ -159,7 +159,7 @@ pub trait Filesystem {
     /// [fuse_common.h](https://libfuse.github.io/doxygen/include_2fuse__common_8h_source.html) for
     /// more details.
     async fn open(&self, req: Request, inode: Inode, flags: u32) -> Result<ReplyOpen> {
-        Err(libc::ENOSYS.into())
+        Ok(ReplyOpen { fh: 0, flags: 0 })
     }
 
     /// read data. Read should send exactly the number of bytes requested except on EOF or error,


### PR DESCRIPTION
A file system implementing stateless opens need not do anything for
FUSE_OPEN except return success.  Make that the default for the fuse3's
Filesystem trait, so implementors don't need to do it explicitly.