### PR TITLE
Change setxattr's value argument to a &[u8]

### DIFF
--- a/src/path/inode_path_bridge.rs
+++ b/src/path/inode_path_bridge.rs
@@ -648,7 +648,7 @@ where
         req: Request,
         inode: u64,
         name: &OsStr,
-        value: &OsStr,
+        value: &[u8],
         flags: u32,
         position: u32,
     ) -> Result<()> {

--- a/src/path/path_filesystem.rs
+++ b/src/path/path_filesystem.rs
@@ -248,7 +248,7 @@ pub trait PathFilesystem {
         req: Request,
         path: &OsStr,
         name: &OsStr,
-        value: &OsStr,
+        value: &[u8],
         flags: u32,
         position: u32,
     ) -> Result<()> {

--- a/src/raw/filesystem.rs
+++ b/src/raw/filesystem.rs
@@ -231,7 +231,7 @@ pub trait Filesystem {
         req: Request,
         inode: Inode,
         name: &OsStr,
-        value: &OsStr,
+        value: &[u8],
         flags: u32,
         position: u32,
     ) -> Result<()> {

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -2155,20 +2155,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
         data = &data[first_null_index + 1..];
 
-        let value = match get_first_null_position(data) {
-            None => {
-                error!(
-                    "fuse_setxattr_in value has no second null unique {}",
-                    request.unique
-                );
-
-                reply_error_in_place(libc::EINVAL.into(), request, &self.response_sender).await;
-
-                return;
-            }
-
-            Some(index) => OsString::from_vec((&data[..index]).to_vec()),
-        };
+        let data = data.to_vec();
 
         let mut resp_sender = self.response_sender.clone();
         let fs = fs.clone();
@@ -2185,7 +2172,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
                     request,
                     in_header.nodeid,
                     &name,
-                    &value,
+                    &data,
                     setxattr_in.flags,
                     0,
                 )


### PR DESCRIPTION
It's perfectly valid for an extended attribute to have binary data with
one, many, or no NUL characters.  fuse3 therefore can't convert it into
an OsString.  Pass the byte slice to the file system instead.

Fixes #14