### PR TITLE
Change ReplyWrite.written to 32 bits

### DIFF
--- a/examples/src/memfs/main.rs
+++ b/examples/src/memfs/main.rs
@@ -793,7 +793,7 @@ impl Filesystem for Fs {
             .write(req, inode_out, fh_out, off_out, data, flags as _)
             .await?;
 
-        Ok(ReplyCopyFileRange { copied: written })
+        Ok(ReplyCopyFileRange { copied: u64::from(written) })
     }
 }
 

--- a/examples/src/path_memfs/main.rs
+++ b/examples/src/path_memfs/main.rs
@@ -862,7 +862,7 @@ impl PathFilesystem for Fs {
             .write(req, to_path, fh_out, offset_out, &data.data, flags as _)
             .await?;
 
-        Ok(ReplyCopyFileRange { copied: written })
+        Ok(ReplyCopyFileRange { copied: u64::from(written) })
     }
 }
 

--- a/src/raw/reply.rs
+++ b/src/raw/reply.rs
@@ -193,13 +193,13 @@ impl From<ReplyOpen> for fuse_open_out {
 /// write reply.
 pub struct ReplyWrite {
     /// the data written.
-    pub written: u64,
+    pub written: u32,
 }
 
 impl From<ReplyWrite> for fuse_write_out {
     fn from(written: ReplyWrite) -> Self {
         fuse_write_out {
-            size: written.written as u32,
+            size: written.written,
             padding: 0,
         }
     }


### PR DESCRIPTION
The fuse_write_in struct only uses 32 bits to request the size of the
write, so there's no point to allocating 64 bits for the response.