### PR TITLE
Fix FUSE_LISTXATTR with size=0

### DIFF
--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -2367,7 +2367,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
                     let out_header = fuse_out_header {
                         len: (FUSE_OUT_HEADER_SIZE + FUSE_GETXATTR_OUT_SIZE) as u32,
-                        error: libc::ERANGE,
+                        error: 0,
                         unique: request.unique,
                     };
 


### PR DESCRIPTION
With size=0, the file system should reply with the size of the list and
errno 0.  errno ERANGE should only be used if the request had a nonzero
size that was too small.