### PR TITLE
By default return ENOSYS for FUSE_OPENDIR

### DIFF
--- a/src/path/path_filesystem.rs
+++ b/src/path/path_filesystem.rs
@@ -160,7 +160,9 @@ pub trait PathFilesystem {
     /// fh, and use this in other all other file operations (read, write, flush, release, fsync).
     /// Filesystem may also implement stateless file I/O and not store anything in fh. There are
     /// also some flags (`direct_io`, `keep_cache`) which the filesystem may set, to change the way
-    /// the file is opened.
+    /// the file is opened.  A file system need not implement this method if it
+    /// sets [`MountOptions::no_open_support`] and if the kernel supports
+    /// `FUSE_NO_OPEN_SUPPORT`.
     ///
     /// # Notes:
     ///
@@ -305,11 +307,11 @@ pub trait PathFilesystem {
     /// `fh`, and use this in other all other directory stream operations
     /// ([`readdir`][PathFilesystem::readdir], [`releasedir`][PathFilesystem::releasedir],
     /// [`fsyncdir`][PathFilesystem::fsyncdir]). Filesystem may also implement stateless directory
-    /// I/O and not store anything in `fh`, though that makes it impossible to implement standard
-    /// conforming directory stream operations in case the contents of the directory can change
-    /// between `opendir` and [`releasedir`][PathFilesystem::releasedir].
+    /// I/O and not store anything in `fh`.  A file system need not implement this method if it
+    /// sets [`MountOptions::no_open_dir_support`] and if the kernel supports
+    /// `FUSE_NO_OPENDIR_SUPPORT`.
     async fn opendir(&self, req: Request, path: &OsStr, flags: u32) -> Result<ReplyOpen> {
-        Ok(ReplyOpen { fh: 0, flags: 0 })
+        Err(libc::ENOSYS.into())
     }
 
     /// read directory. `offset` is used to track the offset of the directory entries. `fh` will

--- a/src/raw/filesystem.rs
+++ b/src/raw/filesystem.rs
@@ -151,7 +151,9 @@ pub trait Filesystem {
     /// fh, and use this in other all other file operations (read, write, flush, release, fsync).
     /// Filesystem may also implement stateless file I/O and not store anything in fh. There are
     /// also some flags (`direct_io`, `keep_cache`) which the filesystem may set, to change the way
-    /// the file is opened.
+    /// the file is opened.  A file system need not implement this method if it
+    /// sets [`MountOptions::no_open_support`] and if the kernel supports
+    /// `FUSE_NO_OPEN_SUPPORT`.
     ///
     /// # Notes:
     ///
@@ -284,11 +286,11 @@ pub trait Filesystem {
     /// `fh`, and use this in other all other directory stream operations
     /// ([`readdir`][Filesystem::readdir], [`releasedir`][Filesystem::releasedir],
     /// [`fsyncdir`][Filesystem::fsyncdir]). Filesystem may also implement stateless directory
-    /// I/O and not store anything in `fh`, though that makes it impossible to implement standard
-    /// conforming directory stream operations in case the contents of the directory can change
-    /// between `opendir` and [`releasedir`][Filesystem::releasedir].
+    /// I/O and not store anything in `fh`.  A file system need not implement this method if it
+    /// sets [`MountOptions::no_open_dir_support`] and if the kernel supports
+    /// `FUSE_NO_OPENDIR_SUPPORT`.
     async fn opendir(&self, req: Request, inode: Inode, flags: u32) -> Result<ReplyOpen> {
-        Ok(ReplyOpen { fh: 0, flags: 0 })
+        Err(libc::ENOSYS.into())
     }
 
     /// read directory. `offset` is used to track the offset of the directory entries. `fh` will

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -780,6 +780,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
             reply_flags |= FUSE_NO_OPENDIR_SUPPORT;
         }
 
+        // TODO: pass init_in to init, so the file system will know which flags are in use.
         if let Err(err) = fs.init(request).await {
             let init_out_header = fuse_out_header {
                 len: FUSE_OUT_HEADER_SIZE as u32,


### PR DESCRIPTION
This makes it work nicely with FUSE_NO_OPENDIR_SUPPORT and mirrors the
behavior for FUSE_OPEN.