### PR TITLE
Make Session::mount semi-synchronous

### DIFF
--- a/examples/src/helloworld/main.rs
+++ b/examples/src/helloworld/main.rs
@@ -334,6 +334,8 @@ async fn main() {
         .mount_with_unprivileged(HelloWorld {}, mount_path)
         .await
         .unwrap()
+        .await
+        .unwrap()
 }
 
 fn log_init() {

--- a/examples/src/memfs/main.rs
+++ b/examples/src/memfs/main.rs
@@ -830,5 +830,7 @@ async fn main() {
     Session::new(mount_options)
         .mount_with_unprivileged(Fs::default(), mount_path)
         .await
+        .unwrap()
+        .await
         .unwrap();
 }

--- a/examples/src/path_memfs/main.rs
+++ b/examples/src/path_memfs/main.rs
@@ -905,5 +905,7 @@ async fn main() {
     Session::new(mount_options)
         .mount_with_unprivileged(Fs::default(), mount_path)
         .await
+        .unwrap()
+        .await
         .unwrap();
 }

--- a/examples/src/poll/main.rs
+++ b/examples/src/poll/main.rs
@@ -382,6 +382,8 @@ async fn main() {
     session
         .mount_with_unprivileged(poll, mount_path)
         .await
+        .unwrap()
+        .await
         .unwrap();
 }
 

--- a/src/path/session.rs
+++ b/src/path/session.rs
@@ -23,7 +23,7 @@ impl Session {
     #[cfg(feature = "unprivileged")]
     /// mount the filesystem without root permission. This function will block until the filesystem
     /// is unmounted.
-    pub async fn mount_with_unprivileged<P, FS>(self, fs: FS, mount_path: P) -> io::Result<()>
+    pub async fn mount_with_unprivileged<P, FS>(self, fs: FS, mount_path: P) -> io::Result<raw::MountHandle>
     where
         P: AsRef<Path>,
         FS: PathFilesystem + Send + Sync + 'static,
@@ -35,7 +35,7 @@ impl Session {
             .await
     }
 
-    pub async fn mount<P, FS>(self, fs: FS, mount_path: P) -> io::Result<()>
+    pub async fn mount<P, FS>(self, fs: FS, mount_path: P) -> io::Result<raw::MountHandle>
     where
         P: AsRef<Path>,
         FS: PathFilesystem + Send + Sync + 'static,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -9,7 +9,7 @@
 pub use filesystem::Filesystem;
 pub use request::Request;
 #[cfg(any(feature = "async-std-runtime", feature = "tokio-runtime"))]
-pub use session::Session;
+pub use session::{MountHandle, Session};
 
 pub(crate) mod abi;
 mod connection;


### PR DESCRIPTION
Session::mount will now return a Future that completes when the mount
does, whose result is another Future that completes when the file system
is unmounted.  This allows consumers to know whether the mount succeeded
without waiting for a future unmount.

Fixes #27