### PR TITLE
Raise Nix dependency to 0.26.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cstr = "0.2"
 libc = "0.2"
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
-nix = { version = "0.25", default-features = false, features = ["fs", "mount", "user"] }
+nix = { version = "0.26.1", default-features = false, features = ["fs", "mount", "user"] }
 which = { version = "4", optional = true }
 tokio-stream = { version = "0.1", features = ["fs"], optional = true }
 async-io = { version = "1", optional = true }


### PR DESCRIPTION
It makes no difference to fuse3 itself, but it allows consuming crates to potentially build fewer versions of Nix.