### PR TITLE
Replace dependency on tokio-stream with function call.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "FUSE user-space library async version implementation."
 members = [".", "examples"]
 
 [features]
-tokio-runtime = ["tokio", "tokio-stream"]
+tokio-runtime = ["tokio"]
 async-std-runtime = ["async-std", "async-io"]
 file-lock = []
 unprivileged = ["nix/socket", "which"]

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -26,7 +26,6 @@ use nix::mount;
 #[cfg(all(not(feature = "async-std-runtime"), feature = "tokio-runtime"))]
 use tokio::{fs::read_dir, task};
 #[cfg(all(not(feature = "async-std-runtime"), feature = "tokio-runtime"))]
-use tokio_stream::wrappers::ReadDirStream;
 use tracing::{debug, debug_span, error, instrument, warn, Instrument, Span};
 
 use crate::helper::*;
@@ -96,12 +95,7 @@ impl<FS> Session<FS> {
 impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
     pub async fn mount_empty_check(&self, mount_path: &Path) -> IoResult<()> {
         #[cfg(all(not(feature = "async-std-runtime"), feature = "tokio-runtime"))]
-        if !self.mount_options.nonempty
-            && ReadDirStream::new(read_dir(mount_path).await?)
-                .next()
-                .await
-                .is_some()
-        {
+        if !self.mount_options.nonempty && read_dir(mount_path).await?.next_entry().await.is_ok() {
             return Err(IoError::new(
                 ErrorKind::AlreadyExists,
                 "mount point is not empty",


### PR DESCRIPTION
This is removing an unnecessary crate dependency with no loss of readability.