### PR TITLE
fix mount with tokio-runtime and nonempty = true

### DIFF
--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -94,7 +94,9 @@ impl<FS> Session<FS> {
 impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
     pub async fn mount_empty_check(&self, mount_path: &Path) -> IoResult<()> {
         #[cfg(all(not(feature = "async-std-runtime"), feature = "tokio-runtime"))]
-        if !self.mount_options.nonempty && read_dir(mount_path).await?.next_entry().await.is_ok() {
+        if !self.mount_options.nonempty
+            && matches!(read_dir(mount_path).await?.next_entry().await, Ok(Some(_)))
+        {
             return Err(IoError::new(
                 ErrorKind::AlreadyExists,
                 "mount point is not empty",


### PR DESCRIPTION
This fix can be verified with the helloworld example. Without the fix, it complains about the mountpoint not being empty even when it is:

```shellSession
$ mkdir /tmp/mountpoint
$ cargo run --bin helloworld -- /tmp/mountpoint
...
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', examples/src/helloworld/main.rs:336:10
...
```

The problem is that, on an empty dir, `read_dir(mount_path).await?.next_entry().await` returns `Ok(None)`, but the nonempty check only makes sense if it finds `Ok(Some(...))`. I was going to write this check as `.is_ok_and(Option::is_some)` instead, but `Result::is_ok_and` is unstable.

@KongzhangHao FYI: It appears that this issue was introduced in #53.