### PR TITLE
Drop minor version dependency for nix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cstr = "0.2"
 libc = "0.2"
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
-nix = { version = "0.26.1", default-features = false, features = ["fs", "mount", "user"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "mount", "user"] }
 which = { version = "4", optional = true }
 async-io = { version = "1", optional = true }
 bytes = "1"


### PR DESCRIPTION
nix 0.26.1 contains bugs and mainline contains pull requests for unsound behavior. It seems unnecessary to track a specific minor version so just depend on 0.26.x instead.

If this seems OK, could you also bump the release version and push to crates.io for me? 