### PR TITLE
feat: add write_flags arguments in the write method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse3"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Sherlock Holo <sherlockya@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/examples/src/memfs/main.rs
+++ b/examples/src/memfs/main.rs
@@ -554,6 +554,7 @@ impl Filesystem for Fs {
         _fh: u64,
         offset: u64,
         mut data: &[u8],
+        _write_flags: u32,
         _flags: u32,
     ) -> Result<ReplyWrite> {
         let inner = self.0.read().await;

--- a/examples/src/path_memfs/main.rs
+++ b/examples/src/path_memfs/main.rs
@@ -518,6 +518,7 @@ impl PathFilesystem for Fs {
         _fh: u64,
         offset: u64,
         data: &[u8],
+        _write_flags: u32,
         _flags: u32,
     ) -> Result<ReplyWrite> {
         let path = path.ok_or_else(Errno::new_not_exist)?.to_string_lossy();
@@ -861,8 +862,9 @@ impl PathFilesystem for Fs {
             .read(req, from_path, fh_in, offset_in, length as _)
             .await?;
 
+        // write_flags set to 0 because we don't care it in this example implement
         let ReplyWrite { written } = self
-            .write(req, to_path, fh_out, offset_out, &data.data, flags as _)
+            .write(req, to_path, fh_out, offset_out, &data.data, 0, flags as _)
             .await?;
 
         Ok(ReplyCopyFileRange {

--- a/src/path/inode_path_bridge.rs
+++ b/src/path/inode_path_bridge.rs
@@ -574,6 +574,7 @@ where
         fh: u64,
         offset: u64,
         data: &[u8],
+        write_flags: u32,
         flags: u32,
     ) -> Result<ReplyWrite> {
         let path = self
@@ -589,6 +590,7 @@ where
                 fh,
                 offset,
                 data,
+                write_flags,
                 flags,
             )
             .await

--- a/src/path/path_filesystem.rs
+++ b/src/path/path_filesystem.rs
@@ -194,7 +194,10 @@ pub trait PathFilesystem {
     /// exception to this is when the file has been opened in `direct_io` mode, in which case the
     /// return value of the write system call will reflect the return value of this operation. `fh`
     /// will contain the value set by the open method, or will be undefined if the open method
-    /// didn't set any value. when `path` is None, it means the path may be deleted.
+    /// didn't set any value. When `path` is None, it means the path may be deleted. When
+    /// `write_flags` contains [`FUSE_WRITE_CACHE`](crate::raw::flags::FUSE_WRITE_CACHE), means the
+    /// write operation is a delay write.
+    #[allow(clippy::too_many_arguments)]
     async fn write(
         &self,
         req: Request,
@@ -202,6 +205,7 @@ pub trait PathFilesystem {
         fh: u64,
         offset: u64,
         data: &[u8],
+        write_flags: u32,
         flags: u32,
     ) -> Result<ReplyWrite> {
         Err(libc::ENOSYS.into())

--- a/src/raw/filesystem.rs
+++ b/src/raw/filesystem.rs
@@ -184,7 +184,10 @@ pub trait Filesystem {
     /// exception to this is when the file has been opened in `direct_io` mode, in which case the
     /// return value of the write system call will reflect the return value of this operation. `fh`
     /// will contain the value set by the open method, or will be undefined if the open method
-    /// didn't set any value.
+    /// didn't set any value. When `write_flags` contains
+    /// [`FUSE_WRITE_CACHE`](crate::raw::flags::FUSE_WRITE_CACHE), means the write operation is a
+    /// delay write.
+    #[allow(clippy::too_many_arguments)]
     async fn write(
         &self,
         req: Request,
@@ -192,6 +195,7 @@ pub trait Filesystem {
         fh: u64,
         offset: u64,
         data: &[u8],
+        write_flags: u32,
         flags: u32,
     ) -> Result<ReplyWrite> {
         Err(libc::ENOSYS.into())

--- a/src/raw/flags.rs
+++ b/src/raw/flags.rs
@@ -1,0 +1,12 @@
+//! request flags.
+
+pub use crate::raw::abi::FUSE_IOCTL_32BIT;
+pub use crate::raw::abi::FUSE_IOCTL_COMPAT;
+pub use crate::raw::abi::FUSE_IOCTL_DIR;
+pub use crate::raw::abi::FUSE_IOCTL_MAX_IOV;
+pub use crate::raw::abi::FUSE_IOCTL_RETRY;
+pub use crate::raw::abi::FUSE_IOCTL_UNRESTRICTED;
+pub use crate::raw::abi::FUSE_POLL_SCHEDULE_NOTIFY;
+pub use crate::raw::abi::FUSE_READ_LOCKOWNER;
+pub use crate::raw::abi::FUSE_WRITE_CACHE;
+pub use crate::raw::abi::FUSE_WRITE_LOCKOWNER;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -14,6 +14,7 @@ pub use session::{MountHandle, Session};
 pub(crate) mod abi;
 mod connection;
 mod filesystem;
+pub mod flags;
 pub mod reply;
 mod request;
 pub(crate) mod session;

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -1873,6 +1873,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
                     write_in.fh,
                     write_in.offset,
                     &data,
+                    write_in.write_flags,
                     write_in.flags,
                 )
                 .await


### PR DESCRIPTION
add `write_flags` in the `write` method, user can use it check if the write operation is a delay write or not