### PR TITLE
fix: docs

### DIFF
--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -308,7 +308,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
     }
 
     /// mount the filesystem without root permission.
-    /// This function will block until [`MountHandle::unmount`] is called.
     #[cfg(all(target_os = "linux", feature = "unprivileged"))]
     pub async fn mount_with_unprivileged<P: AsRef<Path>>(
         mut self,
@@ -343,8 +342,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
         })
     }
 
-    /// mount the filesystem with root permission. This function will block until the filesystem
-    /// is unmounted.
+    /// mount the filesystem with root permission.
     #[cfg(target_os = "linux")]
     pub async fn mount<P: AsRef<Path>>(mut self, fs: FS, mount_path: P) -> IoResult<MountHandle> {
         let mount_path = mount_path.as_ref();
@@ -395,8 +393,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
         })
     }
 
-    /// mount the filesystem. This function will block until the filesystem is
-    /// unmounted.
+    /// mount the filesystem with root permission.
     #[cfg(target_os = "freebsd")]
     pub async fn mount<P: AsRef<Path>>(mut self, fs: FS, mount_path: P) -> IoResult<MountHandle> {
         use cstr::cstr;


### PR DESCRIPTION
`mount` and `mount_with_unprivileged` will return after mount instead of umount.