### PR TITLE
Clippy cleanup

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -93,7 +93,7 @@ impl Notify {
                 let invalid_entry_out = fuse_notify_inval_entry_out {
                     parent: *parent,
                     namelen: name.len() as _,
-                    padding: 0,
+                    _padding: 0,
                 };
 
                 let mut data =
@@ -126,7 +126,7 @@ impl Notify {
                     parent: *parent,
                     child: *child,
                     namelen: name.len() as _,
-                    padding: 0,
+                    _padding: 0,
                 };
 
                 let mut data =
@@ -159,7 +159,7 @@ impl Notify {
                     nodeid: *inode,
                     offset: *offset,
                     size: data.len() as _,
-                    padding: 0,
+                    _padding: 0,
                 };
 
                 let mut data_buf =
@@ -192,7 +192,7 @@ impl Notify {
                     nodeid: *inode,
                     offset: *offset,
                     size: *size,
-                    padding: 0,
+                    _padding: 0,
                 };
 
                 let mut data =

--- a/src/raw/abi.rs
+++ b/src/raw/abi.rs
@@ -256,7 +256,7 @@ pub struct fuse_attr {
     // see chflags(2)
     pub flags: u32,
     pub blksize: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -278,7 +278,7 @@ pub struct fuse_kstatfs {
     pub namelen: u32,
     // Fundamental file system block size
     pub frsize: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
     pub spare: [u32; 6],
 }
 
@@ -435,11 +435,11 @@ impl TryFrom<u32> for fuse_opcode {
 
 /// Invalid notify code error.
 #[derive(Debug)]
-pub struct InvalidNotifyCodeError(pub u32);
+pub struct InvalidNotifyCodeError(u32);
 
 impl Display for InvalidNotifyCodeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(self, f)
+        write!(f, "InvalidNotifyCodeError({})", self.0)
     }
 }
 
@@ -515,7 +515,7 @@ pub const FUSE_FORGET_ONE_SIZE: usize = mem::size_of::<fuse_forget_one>();
 #[allow(non_camel_case_types)]
 pub struct fuse_forget_one {
     pub nodeid: u64,
-    pub nlookup: u64,
+    pub (crate) _nlookup: u64,
 }
 
 pub const FUSE_BATCH_FORGET_IN_SIZE: usize = mem::size_of::<fuse_batch_forget_in>();
@@ -524,7 +524,7 @@ pub const FUSE_BATCH_FORGET_IN_SIZE: usize = mem::size_of::<fuse_batch_forget_in
 #[allow(non_camel_case_types)]
 pub struct fuse_batch_forget_in {
     pub count: u32,
-    pub dummy: u32,
+    pub(crate) _dummy: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -563,8 +563,8 @@ pub const FUSE_MKNOD_IN_SIZE: usize = mem::size_of::<fuse_mknod_in>();
 pub struct fuse_mknod_in {
     pub mode: u32,
     pub rdev: u32,
-    pub umask: u32,
-    pub padding: u32,
+    pub(crate) _umask: u32,
+    _padding: u32,
 }
 
 pub const FUSE_MKDIR_IN_SIZE: usize = mem::size_of::<fuse_mkdir_in>();
@@ -591,7 +591,7 @@ pub const FUSE_RENAME2_IN_SIZE: usize = mem::size_of::<fuse_rename2_in>();
 pub struct fuse_rename2_in {
     pub newdir: u64,
     pub flags: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 #[cfg(target_os = "macos")]
@@ -615,7 +615,7 @@ pub struct fuse_link_in {
 #[allow(non_camel_case_types)]
 pub struct fuse_setattr_in {
     pub valid: u32,
-    pub padding: u32,
+    _padding: u32,
     pub fh: u64,
     pub size: u64,
     pub lock_owner: u64,
@@ -650,7 +650,7 @@ pub struct fuse_setattr_in {
 #[allow(non_camel_case_types)]
 pub struct fuse_open_in {
     pub flags: u32,
-    pub unused: u32,
+    pub(crate) _unused: u32,
 }
 
 pub const FUSE_CREATE_IN_SIZE: usize = mem::size_of::<fuse_create_in>();
@@ -660,8 +660,8 @@ pub const FUSE_CREATE_IN_SIZE: usize = mem::size_of::<fuse_create_in>();
 pub struct fuse_create_in {
     pub flags: u32,
     pub mode: u32,
-    pub umask: u32,
-    pub padding: u32,
+    pub(crate) _umask: u32,
+    _padding: u32,
 }
 
 pub const FUSE_OPEN_OUT_SIZE: usize = mem::size_of::<fuse_open_out>();
@@ -671,7 +671,7 @@ pub const FUSE_OPEN_OUT_SIZE: usize = mem::size_of::<fuse_open_out>();
 pub struct fuse_open_out {
     pub fh: u64,
     pub open_flags: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -687,8 +687,8 @@ pub struct fuse_release_in {
 #[allow(non_camel_case_types)]
 pub struct fuse_flush_in {
     pub fh: u64,
-    pub unused: u32,
-    pub padding: u32,
+    pub(crate) _unused: u32,
+    _padding: u32,
     pub lock_owner: u64,
 }
 
@@ -698,10 +698,10 @@ pub struct fuse_read_in {
     pub fh: u64,
     pub offset: u64,
     pub size: u32,
-    pub read_flags: u32,
+    pub(crate) _read_flags: u32,
     pub lock_owner: u64,
-    pub flags: u32,
-    pub padding: u32,
+    pub(crate) _flags: u32,
+    _padding: u32,
 }
 
 pub const FUSE_WRITE_IN_SIZE: usize = mem::size_of::<fuse_write_in>();
@@ -713,9 +713,9 @@ pub struct fuse_write_in {
     pub offset: u64,
     pub size: u32,
     pub write_flags: u32,
-    pub lock_owner: u64,
+    pub(crate) _lock_owner: u64,
     pub flags: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_WRITE_OUT_SIZE: usize = mem::size_of::<fuse_write_out>();
@@ -724,7 +724,7 @@ pub const FUSE_WRITE_OUT_SIZE: usize = mem::size_of::<fuse_write_out>();
 #[allow(non_camel_case_types)]
 pub struct fuse_write_out {
     pub size: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_STATFS_OUT_SIZE: usize = mem::size_of::<fuse_statfs_out>();
@@ -740,7 +740,7 @@ pub struct fuse_statfs_out {
 pub struct fuse_fsync_in {
     pub fh: u64,
     pub fsync_flags: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_SETXATTR_IN_SIZE: usize = mem::size_of::<fuse_setxattr_in>();
@@ -753,7 +753,7 @@ pub struct fuse_setxattr_in {
     #[cfg(target_os = "macos")]
     pub position: u32,
     #[cfg(target_os = "macos")]
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_GETXATTR_IN_SIZE: usize = mem::size_of::<fuse_getxattr_in>();
@@ -762,11 +762,11 @@ pub const FUSE_GETXATTR_IN_SIZE: usize = mem::size_of::<fuse_getxattr_in>();
 #[allow(non_camel_case_types)]
 pub struct fuse_getxattr_in {
     pub size: u32,
-    pub padding: u32,
+    _padding: u32,
     #[cfg(target_os = "macos")]
     pub position: u32,
     #[cfg(target_os = "macos")]
-    pub padding2: u32,
+    _padding2: u32,
 }
 
 pub const FUSE_GETXATTR_OUT_SIZE: usize = mem::size_of::<fuse_getxattr_out>();
@@ -775,7 +775,7 @@ pub const FUSE_GETXATTR_OUT_SIZE: usize = mem::size_of::<fuse_getxattr_out>();
 #[allow(non_camel_case_types)]
 pub struct fuse_getxattr_out {
     pub size: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 #[cfg(feature = "file-lock")]
@@ -785,8 +785,8 @@ pub struct fuse_lk_in {
     pub fh: u64,
     pub owner: u64,
     pub lk: fuse_file_lock,
-    pub lk_flags: u32,
-    pub padding: u32,
+    pub(crate) _lk_flags: u32,
+    _padding: u32,
 }
 
 #[cfg(feature = "file-lock")]
@@ -803,14 +803,14 @@ pub struct fuse_lk_out {
 #[allow(non_camel_case_types)]
 pub struct fuse_access_in {
     pub mask: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(non_camel_case_types)]
 pub struct fuse_init_in {
-    pub major: u32,
-    pub minor: u32,
+    pub(crate) _major: u32,
+    pub(crate) _minor: u32,
     pub max_readahead: u32,
     pub flags: u32,
 }
@@ -869,7 +869,7 @@ pub struct fuse_interrupt_in {
 pub struct fuse_bmap_in {
     pub block: u64,
     pub blocksize: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_BMAP_OUT_SIZE: usize = mem::size_of::<fuse_bmap_out>();
@@ -880,32 +880,32 @@ pub struct fuse_bmap_out {
     pub block: u64,
 }
 
-#[derive(Debug, Deserialize)]
-#[allow(non_camel_case_types)]
-pub struct fuse_ioctl_in {
-    pub fh: u64,
-    pub flags: u32,
-    pub cmd: u32,
-    pub arg: u64,
-    pub in_size: u32,
-    pub out_size: u32,
-}
+//#[derive(Debug, Deserialize)]
+//#[allow(non_camel_case_types)]
+//pub struct fuse_ioctl_in {
+    //pub fh: u64,
+    //pub flags: u32,
+    //pub cmd: u32,
+    //pub arg: u64,
+    //pub in_size: u32,
+    //pub out_size: u32,
+//}
 
-#[derive(Debug)]
-#[allow(non_camel_case_types)]
-pub struct fuse_ioctl_iovec {
-    pub base: u64,
-    pub len: u64,
-}
+//#[derive(Debug)]
+//#[allow(non_camel_case_types)]
+//pub struct fuse_ioctl_iovec {
+    //pub base: u64,
+    //pub len: u64,
+//}
 
-#[derive(Debug)]
-#[allow(non_camel_case_types)]
-pub struct fuse_ioctl_out {
-    pub result: i32,
-    pub flags: u32,
-    pub in_iovs: u32,
-    pub out_iovs: u32,
-}
+//#[derive(Debug)]
+//#[allow(non_camel_case_types)]
+//pub struct fuse_ioctl_out {
+    //pub result: i32,
+    //pub flags: u32,
+    //pub in_iovs: u32,
+    //pub out_iovs: u32,
+//}
 
 #[derive(Debug, Deserialize)]
 #[allow(non_camel_case_types)]
@@ -922,7 +922,7 @@ pub const FUSE_POLL_OUT_SIZE: usize = mem::size_of::<fuse_poll_out>();
 #[allow(non_camel_case_types)]
 pub struct fuse_poll_out {
     pub revents: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_NOTIFY_POLL_WAKEUP_OUT_SIZE: usize = mem::size_of::<fuse_notify_poll_wakeup_out>();
@@ -940,7 +940,7 @@ pub struct fuse_fallocate_in {
     pub offset: u64,
     pub length: u64,
     pub mode: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_IN_HEADER_SIZE: usize = mem::size_of::<fuse_in_header>();
@@ -955,7 +955,7 @@ pub struct fuse_in_header {
     pub uid: u32,
     pub gid: u32,
     pub pid: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_OUT_HEADER_SIZE: usize = mem::size_of::<fuse_out_header>();
@@ -1006,7 +1006,7 @@ pub const FUSE_NOTIFY_INVAL_ENTRY_OUT_SIZE: usize = mem::size_of::<fuse_notify_i
 pub struct fuse_notify_inval_entry_out {
     pub parent: u64,
     pub namelen: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_NOTIFY_DELETE_OUT_SIZE: usize = mem::size_of::<fuse_notify_delete_out>();
@@ -1017,7 +1017,7 @@ pub struct fuse_notify_delete_out {
     pub parent: u64,
     pub child: u64,
     pub namelen: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_NOTIFY_STORE_OUT_SIZE: usize = mem::size_of::<fuse_notify_store_out>();
@@ -1028,7 +1028,7 @@ pub struct fuse_notify_store_out {
     pub nodeid: u64,
     pub offset: u64,
     pub size: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_NOTIFY_RETRIEVE_OUT_SIZE: usize = mem::size_of::<fuse_notify_retrieve_out>();
@@ -1040,7 +1040,7 @@ pub struct fuse_notify_retrieve_out {
     pub nodeid: u64,
     pub offset: u64,
     pub size: u32,
-    pub padding: u32,
+    pub(crate) _padding: u32,
 }
 
 pub const FUSE_NOTIFY_RETRIEVE_IN_SIZE: usize = mem::size_of::<fuse_notify_retrieve_in>();
@@ -1049,12 +1049,12 @@ pub const FUSE_NOTIFY_RETRIEVE_IN_SIZE: usize = mem::size_of::<fuse_notify_retri
 // matches the size of fuse_write_in
 #[allow(non_camel_case_types)]
 pub struct fuse_notify_retrieve_in {
-    pub dummy1: u64,
+    _dummy1: u64,
     pub offset: u64,
     pub size: u32,
-    pub dummy2: u32,
-    pub dummy3: u64,
-    pub dummy4: u64,
+    _dummy2: u32,
+    _dummy3: u64,
+    _dummy4: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1063,7 +1063,7 @@ pub struct fuse_lseek_in {
     pub fh: u64,
     pub offset: u64,
     pub whence: u32,
-    pub padding: u32,
+    _padding: u32,
 }
 
 pub const FUSE_LSEEK_OUT_SIZE: usize = mem::size_of::<fuse_lseek_out>();

--- a/src/raw/connection/tokio.rs
+++ b/src/raw/connection/tokio.rs
@@ -9,18 +9,16 @@ use std::io;
 use std::io::ErrorKind;
 #[cfg(target_os = "linux")]
 use std::io::Write;
-use std::io::{IoSlice, IoSliceMut, Read};
-use std::mem::ManuallyDrop;
+use std::io::{IoSlice, IoSliceMut};
 use std::ops::{Deref, DerefMut};
 #[cfg(any(
     all(target_os = "linux", feature = "unprivileged"),
     target_os = "freebsd"
 ))]
 use std::os::fd::OwnedFd;
-use std::os::fd::{AsFd, BorrowedFd, FromRawFd};
+use std::os::fd::{AsFd, BorrowedFd};
 #[cfg(target_os = "freebsd")]
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::AsRawFd;
 #[cfg(all(target_os = "linux", feature = "unprivileged"))]
 use std::os::unix::io::RawFd;
 use std::pin::pin;
@@ -198,6 +196,10 @@ impl BlockFuseConnection {
         mut header_buf: Vec<u8>,
         mut data_buf: T,
     ) -> CompleteIoResult<(Vec<u8>, T), usize> {
+        use std::io::Read;
+        use std::mem::ManuallyDrop;
+        use std::os::fd::{AsRawFd, FromRawFd};
+
         let _guard = self.read.lock().await;
         let fd = self.file.as_raw_fd();
 
@@ -291,6 +293,8 @@ impl NonBlockFuseConnection {
         mount_options: MountOptions,
         mount_path: impl AsRef<Path>,
     ) -> io::Result<Self> {
+        use std::os::fd::{AsRawFd, FromRawFd};
+
         let (sock0, sock1) = match socket::socketpair(
             AddressFamily::Unix,
             SockType::SeqPacket,

--- a/src/raw/reply.rs
+++ b/src/raw/reply.rs
@@ -72,7 +72,7 @@ impl From<FileAttr> for fuse_attr {
             gid: attr.gid,
             rdev: attr.rdev,
             blksize: attr.blksize,
-            padding: 0,
+            _padding: 0,
         }
     }
 }
@@ -162,7 +162,7 @@ impl From<ReplyOpen> for fuse_open_out {
         fuse_open_out {
             fh: opened.fh,
             open_flags: opened.flags,
-            padding: 0,
+            _padding: 0,
         }
     }
 }
@@ -178,7 +178,7 @@ impl From<ReplyWrite> for fuse_write_out {
     fn from(written: ReplyWrite) -> Self {
         fuse_write_out {
             size: written.written,
-            padding: 0,
+            _padding: 0,
         }
     }
 }
@@ -216,7 +216,7 @@ impl From<ReplyStatFs> for fuse_statfs_out {
                 bsize: stat_fs.bsize,
                 namelen: stat_fs.namelen,
                 frsize: stat_fs.frsize,
-                padding: 0,
+                _padding: 0,
                 spare: [0; 6],
             },
         }
@@ -312,7 +312,7 @@ impl From<ReplyCreated> for (fuse_entry_out, fuse_open_out) {
         let open_out = fuse_open_out {
             fh: created.fh,
             open_flags: created.flags,
-            padding: 0,
+            _padding: 0,
         };
 
         (entry_out, open_out)
@@ -351,7 +351,7 @@ impl From<ReplyPoll> for fuse_poll_out {
     fn from(poll: ReplyPoll) -> Self {
         fuse_poll_out {
             revents: poll.revents,
-            padding: 0,
+            _padding: 0,
         }
     }
 }
@@ -408,7 +408,7 @@ impl From<ReplyCopyFileRange> for fuse_write_out {
     fn from(copied: ReplyCopyFileRange) -> Self {
         fuse_write_out {
             size: copied.copied as u32,
-            padding: 0,
+            _padding: 0,
         }
     }
 }

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -2605,7 +2605,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
             let data = match xattr {
                 ReplyXAttr::Size(size) => {
-                    let getxattr_out = fuse_getxattr_out { size, padding: 0 };
+                    let getxattr_out = fuse_getxattr_out { size, _padding: 0 };
 
                     let out_header = fuse_out_header {
                         len: (FUSE_OUT_HEADER_SIZE + FUSE_GETXATTR_OUT_SIZE) as u32,
@@ -2695,7 +2695,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
 
             let data = match xattr {
                 ReplyXAttr::Size(size) => {
-                    let getxattr_out = fuse_getxattr_out { size, padding: 0 };
+                    let getxattr_out = fuse_getxattr_out { size, _padding: 0 };
 
                     let out_header = fuse_out_header {
                         len: (FUSE_OUT_HEADER_SIZE + FUSE_GETXATTR_OUT_SIZE) as u32,


### PR DESCRIPTION
Mostly, clean up a lot of unused fields, delete some unused structs (but leave them commented out in case somebody implements FUSE_IOCTL), and clean up some use statements.