### PR TITLE
Use native CStr literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,17 +272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "cstr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212f2ff7df2a16b9ef4c82d7ff45cb065659ccd6c6c36850f1ae8286041232e4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +368,6 @@ dependencies = [
  "async-process",
  "bincode",
  "bytes",
- "cstr",
  "futures-channel",
  "futures-util",
  "libc",
@@ -435,7 +423,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn",
 ]
 
 [[package]]
@@ -667,7 +655,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn",
 ]
 
 [[package]]
@@ -711,17 +699,6 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -782,7 +759,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn",
 ]
 
 [[package]]
@@ -804,7 +781,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn",
 ]
 
 [[package]]
@@ -850,7 +827,7 @@ checksum = "96cbd06a7b648f1603e60d75d9ed295d096b340d30e9f9324f4b512b5d40cd92"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["api-bindings", "filesystem"]
 license = "MIT"
 repository = "https://github.com/Sherlock-Holo/fuse3"
 description = "FUSE user-space library async version implementation."
-rust-version = "1.75"
+rust-version = "1.77"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -31,7 +31,6 @@ async-io = { version = "2.3.1", optional = true }
 async-process = { version = "2.1.0", optional = true }
 bincode = "1.3.3"
 bytes = "1.5"
-cstr = "0.2"
 futures-channel = { version = "0.3.30", features = ["sink"] }
 futures-util = { version = "0.3.30", features = ["sink"] }
 libc = "0.2.153"

--- a/src/mount_options.rs
+++ b/src/mount_options.rs
@@ -181,26 +181,24 @@ impl MountOptions {
 
     #[cfg(target_os = "freebsd")]
     pub(crate) fn build(&self) -> Nmount {
-        use cstr::cstr;
-
         let mut nmount = Nmount::new();
         nmount
-            .str_opt(cstr!("fstype"), cstr!("fusefs"))
-            .str_opt(cstr!("from"), cstr!("/dev/fuse"));
+            .str_opt(c"fstype", c"fusefs")
+            .str_opt(c"from", c"/dev/fuse");
         if self.allow_other {
-            nmount.null_opt(cstr!("allow_other"));
+            nmount.null_opt(c"allow_other");
         }
         if self.allow_root {
-            nmount.null_opt(cstr!("allow_root"));
+            nmount.null_opt(c"allow_root");
         }
         if self.default_permissions {
-            nmount.null_opt(cstr!("default_permissions"));
+            nmount.null_opt(c"default_permissions");
         }
         if let Some(fs_name) = &self.fs_name {
-            nmount.str_opt_owned(cstr!("subtype="), fs_name.as_str());
+            nmount.str_opt_owned(c"subtype=", fs_name.as_str());
         }
         if self.intr {
-            nmount.null_opt(cstr!("intr"));
+            nmount.null_opt(c"intr");
         }
         if let Some(custom_options) = self.custom_options.as_ref() {
             nmount.null_opt_owned(custom_options.as_os_str());

--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -396,8 +396,6 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
     /// mount the filesystem with root permission.
     #[cfg(target_os = "freebsd")]
     pub async fn mount<P: AsRef<Path>>(mut self, fs: FS, mount_path: P) -> IoResult<MountHandle> {
-        use cstr::cstr;
-
         let mount_path = mount_path.as_ref();
 
         self.mount_empty_check(mount_path).await?;
@@ -410,8 +408,8 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
         {
             let mut nmount = self.mount_options.build();
             nmount
-                .str_opt_owned(cstr!("fspath"), mount_path)
-                .str_opt_owned(cstr!("fd"), format!("{}", fd).as_str());
+                .str_opt_owned(c"fspath", mount_path)
+                .str_opt_owned(c"fd", format!("{}", fd).as_str());
             debug!("mount options {:?}", &nmount);
 
             if let Err(err) = nmount.nmount(self.mount_options.flags()) {


### PR DESCRIPTION
This eliminates the cstr and syn-1 crates, and raises MSRV to 1.77.0

Fixes #93