### PR TITLE
Remove a misleading doc comment

### DIFF
--- a/src/raw/session.rs
+++ b/src/raw/session.rs
@@ -393,7 +393,7 @@ impl<FS: Filesystem + Send + Sync + 'static> Session<FS> {
         })
     }
 
-    /// mount the filesystem without root permission.
+    /// mount the filesystem
     #[cfg(target_os = "freebsd")]
     pub async fn mount<P: AsRef<Path>>(mut self, fs: FS, mount_path: P) -> IoResult<MountHandle> {
         use cstr::cstr;


### PR DESCRIPTION
On FreeBSD, the same procedure is used to mount a fuse file system whether or not the process is privileged.