### PR TITLE
Fix the unmount notification for unprivileged mounts.

### DIFF
--- a/src/raw/connection/tokio.rs
+++ b/src/raw/connection/tokio.rs
@@ -43,9 +43,9 @@ use nix::{
     all(target_os = "linux", feature = "unprivileged"),
     target_os = "freebsd"
 ))]
-use tokio::io::unix::AsyncFd;
+use tokio::io::{unix::AsyncFd, Interest};
 #[cfg(all(target_os = "linux", feature = "unprivileged"))]
-use tokio::{process::Command, io::Interest};
+use tokio::process::Command;
 #[cfg(target_os = "linux")]
 use tokio::task;
 #[cfg(all(target_os = "linux", feature = "unprivileged"))]

--- a/src/raw/connection/tokio.rs
+++ b/src/raw/connection/tokio.rs
@@ -45,7 +45,7 @@ use nix::{
 ))]
 use tokio::io::unix::AsyncFd;
 #[cfg(all(target_os = "linux", feature = "unprivileged"))]
-use tokio::process::Command;
+use tokio::{process::Command, io::Interest};
 #[cfg(target_os = "linux")]
 use tokio::task;
 #[cfg(all(target_os = "linux", feature = "unprivileged"))]
@@ -395,7 +395,7 @@ impl NonBlockFuseConnection {
         let _guard = self.read.lock().await;
 
         loop {
-            let mut read_guard = match self.fd.readable().await {
+            let mut read_guard = match self.fd.ready(Interest::READABLE | Interest::ERROR).await {
                 Err(err) => return ((header_buf, data_buf), Err(err)),
                 Ok(read_guard) => read_guard,
             };


### PR DESCRIPTION
It's adding `tokio::io::Interrest::ERROR` to the list of awaited state changes. 
Otherwise we don't get `ENODEV` which signals `Fuse` unmount events.

Fixes: https://github.com/Sherlock-Holo/fuse3/issues/102
