### PR TITLE
Use RPITIT instead of associated types for readdir(plus)

### DIFF
--- a/examples/src/helloworld/main.rs
+++ b/examples/src/helloworld/main.rs
@@ -1,15 +1,13 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::iter::Skip;
 use std::num::NonZeroU32;
 use std::time::{Duration, SystemTime};
-use std::vec::IntoIter;
 
 use bytes::Bytes;
 use fuse3::raw::prelude::*;
-use fuse3::{MountOptions, Result, Timestamp};
+use fuse3::{MountOptions, Result};
 use futures_util::stream;
-use futures_util::stream::Iter;
+use futures_util::stream::Stream;
 use tracing::Level;
 
 const CONTENT: &str = "hello world\n";
@@ -169,18 +167,13 @@ impl Filesystem for HelloWorld {
         }
     }
 
-    type DirEntryStream<'a>
-        = Iter<Skip<IntoIter<Result<DirectoryEntry>>>>
-    where
-        Self: 'a;
-
     async fn readdir(
         &self,
         _req: Request,
         inode: u64,
         _fh: u64,
         offset: i64,
-    ) -> Result<ReplyDirectory<Self::DirEntryStream<'_>>> {
+    ) -> Result<ReplyDirectory<impl Stream<Item = Result<DirectoryEntry>> + Send + '_>> {
         if inode == FILE_INODE {
             return Err(libc::ENOTDIR.into());
         }
@@ -223,11 +216,6 @@ impl Filesystem for HelloWorld {
         Ok(())
     }
 
-    type DirEntryPlusStream<'a>
-        = Iter<Skip<IntoIter<Result<DirectoryEntryPlus>>>>
-    where
-        Self: 'a;
-
     async fn readdirplus(
         &self,
         _req: Request,
@@ -235,7 +223,8 @@ impl Filesystem for HelloWorld {
         _fh: u64,
         offset: u64,
         _lock_owner: u64,
-    ) -> Result<ReplyDirectoryPlus<Self::DirEntryPlusStream<'_>>> {
+    ) -> Result<ReplyDirectoryPlus<impl Stream<Item = Result<DirectoryEntryPlus>> + Send + '_>>
+    {
         if parent == FILE_INODE {
             return Err(libc::ENOTDIR.into());
         }

--- a/src/path/path_filesystem.rs
+++ b/src/path/path_filesystem.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 
 use bytes::Bytes;
-use futures_util::stream::Stream;
+use futures_util::stream::{Empty, Stream};
 
 use super::reply::*;
 use super::Request;
@@ -300,11 +300,6 @@ pub trait PathFilesystem {
         Err(libc::ENOSYS.into())
     }
 
-    /// dir entry stream given by [`readdir`][PathFilesystem::readdir].
-    type DirEntryStream<'a>: Stream<Item = Result<DirectoryEntry>> + Send + 'a
-    where
-        Self: 'a;
-
     /// read directory. `offset` is used to track the offset of the directory entries. `fh` will
     /// contain the value set by the [`opendir`][PathFilesystem::opendir] method, or will be
     /// undefined if the [`opendir`][PathFilesystem::opendir] method didn't set any value.
@@ -314,8 +309,8 @@ pub trait PathFilesystem {
         path: &'a OsStr,
         fh: u64,
         offset: i64,
-    ) -> Result<ReplyDirectory<Self::DirEntryStream<'a>>> {
-        Err(libc::ENOSYS.into())
+    ) -> Result<ReplyDirectory<impl Stream<Item = Result<DirectoryEntry>> + Send + 'a>> {
+        Err::<ReplyDirectory<Empty<_>>, _>(libc::ENOSYS.into())
     }
 
     /// release an open directory. For every [`opendir`][PathFilesystem::opendir] call there will
@@ -489,11 +484,6 @@ pub trait PathFilesystem {
         Err(libc::ENOSYS.into())
     }
 
-    /// dir entry plus stream given by [`readdirplus`][PathFilesystem::readdirplus].
-    type DirEntryPlusStream<'a>: Stream<Item = Result<DirectoryEntryPlus>> + Send + 'a
-    where
-        Self: 'a;
-
     /// read directory entries, but with their attribute, like [`readdir`][PathFilesystem::readdir]
     /// + [`lookup`][PathFilesystem::lookup] at the same time.
     async fn readdirplus<'a>(
@@ -503,8 +493,9 @@ pub trait PathFilesystem {
         fh: u64,
         offset: u64,
         lock_owner: u64,
-    ) -> Result<ReplyDirectoryPlus<Self::DirEntryPlusStream<'a>>> {
-        Err(libc::ENOSYS.into())
+    ) -> Result<ReplyDirectoryPlus<impl Stream<Item = Result<DirectoryEntryPlus>> + Send + 'a>>
+    {
+        Err::<ReplyDirectoryPlus<Empty<_>>, _>(libc::ENOSYS.into())
     }
 
     /// rename a file or directory with flags.

--- a/src/raw/filesystem.rs
+++ b/src/raw/filesystem.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 
 use bytes::Bytes;
-use futures_util::stream::Stream;
+use futures_util::stream::{Empty, Stream};
 
 use crate::notify::Notify;
 use crate::raw::reply::*;
@@ -285,11 +285,6 @@ pub trait Filesystem {
         Err(libc::ENOSYS.into())
     }
 
-    /// dir entry stream given by [`readdir`][Filesystem::readdir].
-    type DirEntryStream<'a>: Stream<Item = Result<DirectoryEntry>> + Send + 'a
-    where
-        Self: 'a;
-
     /// read directory. `offset` is used to track the offset of the directory entries. `fh` will
     /// contain the value set by the [`opendir`][Filesystem::opendir] method, or will be
     /// undefined if the [`opendir`][Filesystem::opendir] method didn't set any value.
@@ -299,8 +294,8 @@ pub trait Filesystem {
         parent: Inode,
         fh: u64,
         offset: i64,
-    ) -> Result<ReplyDirectory<Self::DirEntryStream<'a>>> {
-        Err(libc::ENOSYS.into())
+    ) -> Result<ReplyDirectory<impl Stream<Item = Result<DirectoryEntry>> + Send + 'a>> {
+        Err::<ReplyDirectory<Empty<_>>, _>(libc::ENOSYS.into())
     }
 
     /// release an open directory. For every [`opendir`][Filesystem::opendir] call there will
@@ -474,11 +469,6 @@ pub trait Filesystem {
         Err(libc::ENOSYS.into())
     }
 
-    /// dir entry plus stream given by [`readdirplus`][Filesystem::readdirplus].
-    type DirEntryPlusStream<'a>: Stream<Item = Result<DirectoryEntryPlus>> + Send + 'a
-    where
-        Self: 'a;
-
     /// read directory entries, but with their attribute, like [`readdir`][Filesystem::readdir]
     /// + [`lookup`][Filesystem::lookup] at the same time.
     async fn readdirplus<'a>(
@@ -488,8 +478,9 @@ pub trait Filesystem {
         fh: u64,
         offset: u64,
         lock_owner: u64,
-    ) -> Result<ReplyDirectoryPlus<Self::DirEntryPlusStream<'a>>> {
-        Err(libc::ENOSYS.into())
+    ) -> Result<ReplyDirectoryPlus<impl Stream<Item = Result<DirectoryEntryPlus>> + Send + 'a>>
+    {
+        Err::<ReplyDirectoryPlus<Empty<_>>, _>(libc::ENOSYS.into())
     }
 
     /// rename a file or directory with flags.


### PR DESCRIPTION
Return-position `impl Trait` is often easier to use because users don't need to explicitly write the exact type they return, which can be pretty long. It also allows types that involve a closure (eg. involving `stream.map()`) because a closure's type can't be expressed in an associated type.